### PR TITLE
Fix the null loop when server connection breaks or user logs out

### DIFF
--- a/newbank/client/ExampleClient.java
+++ b/newbank/client/ExampleClient.java
@@ -25,6 +25,10 @@ public class ExampleClient extends Thread{
 				try {
 					while(true) {
 						String response = bankServerIn.readLine();
+						if(response == null) { // If no resposne 
+							System.out.println("Server error.");
+							break;
+						}
 						System.out.println(response);
 					}
 				} catch (IOException e) {

--- a/newbank/server/NewBankClientHandler.java
+++ b/newbank/server/NewBankClientHandler.java
@@ -131,21 +131,23 @@ public class NewBankClientHandler extends Thread {
 
     public void run() {
         try {
-            boolean accountToLogIn = askDoesClientHaveAccount();
-            CustomerID customer = null;
-            while (customer == null) {
-            if (accountToLogIn) {
-                customer = loginUser();
-            } else {
-                customer = createAccount();
-            }
-            if (customer == null) {
-                out.println("Failed");
-            }
-            }
-            // if the user is authenticated then get requests from the user and process them
-            out.println("Success! What do you want to do next?");
-            processUserRequests(customer);
+            while(true) { // Loop when the client breaks out of the processUserRequests method, resetting the run() process
+                boolean accountToLogIn = askDoesClientHaveAccount();
+                CustomerID customer = null;
+                while (customer == null) {
+                if (accountToLogIn) {
+                    customer = loginUser();
+                } else {
+                    customer = createAccount();
+                }
+                if (customer == null) {
+                    out.println("Failed");
+                }
+                }
+                // if the user is authenticated then get requests from the user and process them
+                out.println("Success! What do you want to do next?");
+                processUserRequests(customer);
+            }  
         } finally {
             closeStreams();
         }


### PR DESCRIPTION
In NewBankClientHandler the run() method will loop if the client logs out, allowing a new client to log in.
In addition, if the server stops, the client will display an error message instead of looping "null".